### PR TITLE
Update color scheme from brand colors to neutral theme

### DIFF
--- a/client/components/MaskedInfoTicker.tsx
+++ b/client/components/MaskedInfoTicker.tsx
@@ -73,7 +73,7 @@ export default function MaskedInfoTicker({
             transition={{ type: "spring", stiffness: 300, damping: 26 }}
             className="absolute inset-0 flex items-center justify-center text-[13px] md:text-sm font-semibold tracking-wide text-brand-700 dark:text-brand-300"
           >
-            <span className="[text-shadow:0_6px_16px_rgba(79,70,229,0.25)]">
+            <span className="[text-shadow:0_6px_16px_rgba(0,0,0,0.25)]">
               {list[index]}
             </span>
           </motion.div>

--- a/client/components/home/FeatureGrid.tsx
+++ b/client/components/home/FeatureGrid.tsx
@@ -110,10 +110,10 @@ function FeatureCard({ feature }: FeatureCardProps) {
         onPointerMove={handlePointerMove}
         onPointerEnter={(event) => handlePointerMove(event)}
         className={cn(
-          "relative h-full overflow-hidden rounded-3xl border border-white/15 bg-white/10 px-7 py-8 text-left backdrop-blur-2xl",
-          "shadow-[0_18px_36px_-24px_rgba(15,23,42,0.6)] transition-[transform,box-shadow] duration-150 ease-out will-change-transform",
-          "before:pointer-events-none before:absolute before:inset-0 before:rounded-3xl before:bg-gradient-to-br before:from-white/35 before:via-white/10 before:to-transparent before:opacity-70",
-          "hover:shadow-[0_22px_48px_-28px_rgba(15,23,42,0.7)] dark:border-white/10 dark:bg-white/5 dark:before:from-white/15 dark:shadow-[0_18px_38px_-26px_rgba(0,0,0,0.75)] dark:hover:shadow-[0_22px_50px_-30px_rgba(0,0,0,0.82)]",
+          "relative h-full overflow-hidden rounded-3xl border border-border/70 bg-card/80 px-7 py-8 text-left backdrop-blur-2xl",
+          "shadow-[0_18px_36px_-24px_rgba(0,0,0,0.35)] transition-[transform,box-shadow] duration-150 ease-out will-change-transform",
+          "before:pointer-events-none before:absolute before:inset-0 before:rounded-3xl before:bg-gradient-to-br before:from-foreground/10 before:via-foreground/5 before:to-transparent before:opacity-70",
+          "hover:shadow-[0_22px_48px_-28px_rgba(0,0,0,0.5)] dark:border-border/50 dark:bg-card/60 dark:before:from-foreground/15 dark:shadow-[0_18px_38px_-26px_rgba(0,0,0,0.58)] dark:hover:shadow-[0_22px_50px_-30px_rgba(0,0,0,0.7)]",
         )}
         style={
           {

--- a/client/components/layout/Header.tsx
+++ b/client/components/layout/Header.tsx
@@ -66,7 +66,7 @@ export function Header() {
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
                   <button
-                    className="relative inline-flex overflow-hidden items-center rounded-full border border-brand-700/50 bg-brand-800/20 px-3 py-1 text-xs font-semibold text-primary-foreground shadow-[0_12px_22px_-18px_rgba(0,0,0,0.55)] backdrop-blur-xl transition-transform duration-300 hover:scale-[1.02] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-600/40 focus-visible:ring-offset-2 focus-visible:ring-offset-background dark:border-brand-400/40 dark:bg-brand-200/15 dark:text-foreground"
+                    className="relative inline-flex overflow-hidden items-center rounded-full border border-brand-700/50 bg-brand-800/20 px-3 py-1 text-xs font-semibold text-primary-foreground shadow-[0_12px_22px_-18px_rgba(0,0,0,0.55)] backdrop-blur-xl transition-transform duration-300 hover:scale-[1.02] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-600/40 focus-visible:ring-offset-2 focus-visible:ring-offset-background dark:border-brand-600/40 dark:bg-brand-500/15 dark:text-foreground"
                     title="Searches remaining"
                   >
                     <span

--- a/client/components/layout/Header.tsx
+++ b/client/components/layout/Header.tsx
@@ -47,7 +47,7 @@ export function Header() {
               key={item.to}
               to={item.to}
               className={({ isActive }) =>
-                `relative text-sm font-semibold tracking-tight transition-all ${isActive ? "text-foreground" : "text-foreground/70"} hover:text-foreground after:absolute after:left-0 after:-bottom-1 after:h-0.5 after:w-full after:origin-left after:scale-x-0 after:bg-amber-400/70 after:transition-transform hover:after:scale-x-100`
+                `relative text-sm font-semibold tracking-tight transition-all ${isActive ? "text-foreground" : "text-foreground/70"} hover:text-foreground after:absolute after:left-0 after:-bottom-1 after:h-0.5 after:w-full after:origin-left after:scale-x-0 after:bg-foreground/40 after:transition-transform hover:after:scale-x-100`
               }
             >
               {item.label}
@@ -66,14 +66,14 @@ export function Header() {
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
                   <button
-                    className="relative inline-flex overflow-hidden items-center rounded-full border border-amber-400/50 bg-amber-500/20 px-3 py-1 text-xs font-semibold text-amber-100 shadow-[0_12px_22px_-18px_rgba(15,23,42,0.72)] backdrop-blur-xl transition-transform duration-300 hover:scale-[1.02] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-300/70 focus-visible:ring-offset-2 focus-visible:ring-offset-background dark:border-amber-300/40 dark:bg-amber-500/15"
+                    className="relative inline-flex overflow-hidden items-center rounded-full border border-brand-700/50 bg-brand-800/20 px-3 py-1 text-xs font-semibold text-primary-foreground shadow-[0_12px_22px_-18px_rgba(0,0,0,0.55)] backdrop-blur-xl transition-transform duration-300 hover:scale-[1.02] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-600/40 focus-visible:ring-offset-2 focus-visible:ring-offset-background dark:border-brand-400/40 dark:bg-brand-200/15 dark:text-foreground"
                     title="Searches remaining"
                   >
                     <span
                       aria-hidden
-                      className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(255,215,99,0.32),transparent_70%)] opacity-80"
+                      className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,hsl(var(--brand-600)/0.35),transparent_70%)] opacity-80"
                     />
-                    <span className="relative z-10 text-[0.7rem] font-semibold uppercase tracking-[0.22em] text-amber-50">
+                    <span className="relative z-10 text-[0.7rem] font-semibold uppercase tracking-[0.22em] text-primary-foreground">
                       <span className="hidden sm:inline">Balance:</span>{" "}
                       {computeRemaining(profile)}
                     </span>

--- a/client/components/results/ResultsList.tsx
+++ b/client/components/results/ResultsList.tsx
@@ -109,7 +109,7 @@ function ResultCard({
       : undefined;
 
   return (
-    <article className="group relative flex h-full w-full flex-col overflow-hidden rounded-[26px] border border-border/60 bg-background/96 p-6 shadow-[0_18px_34px_-22px_rgba(15,23,42,0.55)] backdrop-blur-xl transition-all duration-300 hover:-translate-y-1 hover:border-border/70 hover:shadow-[0_22px_45px_-26px_rgba(15,23,42,0.68)] dark:shadow-[0_18px_36px_-24px_rgba(0,0,0,0.7)] dark:hover:shadow-[0_22px_48px_-28px_rgba(0,0,0,0.78)]">
+    <article className="group relative flex h-full w-full flex-col overflow-hidden rounded-[26px] border border-border/60 bg-background/96 p-6 shadow-[0_18px_34px_-22px_rgba(0,0,0,0.45)] backdrop-blur-xl transition-all duration-300 hover:-translate-y-1 hover:border-border/70 hover:shadow-[0_22px_45px_-26px_rgba(0,0,0,0.6)] dark:shadow-[0_18px_36px_-24px_rgba(0,0,0,0.62)] dark:hover:shadow-[0_22px_48px_-28px_rgba(0,0,0,0.75)]">
       <div className="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,theme(colors.brand.500/0.12),transparent_65%)] opacity-75" />
       <header className="flex items-center justify-between text-[0.65rem] font-semibold uppercase tracking-[0.3em] text-foreground/60">
         <span className="inline-flex items-center gap-2">
@@ -219,7 +219,7 @@ function InfoTile({
               href={href}
               target="_blank"
               rel="noopener noreferrer"
-              className="text-base font-semibold leading-6 text-amber-300 underline-offset-4 transition-colors hover:text-amber-200 hover:underline break-words"
+              className="break-words text-base font-semibold leading-6 text-brand-800 underline underline-offset-4 transition-colors hover:text-brand-900"
             >
               {displayValue}
             </a>
@@ -311,7 +311,7 @@ function ValueRenderer({ value }: { value: ResultValue }) {
             {primitives.map((primitive, index) => (
               <span
                 key={`${primitive}-${index}`}
-                className="inline-flex items-center rounded-full border border-border/60 bg-background/90 px-3 py-1 text-xs font-semibold text-foreground/90 shadow-[0_6px_12px_-8px_rgba(15,23,42,0.45)]"
+                className="inline-flex items-center rounded-full border border-border/60 bg-background/90 px-3 py-1 text-xs font-semibold text-foreground/90 shadow-[0_6px_12px_-8px_rgba(0,0,0,0.45)]"
               >
                 {String(primitive)}
               </span>

--- a/client/components/ui/button.tsx
+++ b/client/components/ui/button.tsx
@@ -5,15 +5,15 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const gradientInteractive =
-  "text-white [background-size:260%_260%] bg-[linear-gradient(115deg,#4ade80_0%,#06b6d4_50%,#38bdf8_100%)] hover:bg-[linear-gradient(115deg,#38bdf8_0%,#06b6d4_50%,#4ade80_100%)] motion-safe:animation-[gradient-x_8s_linear_infinite] motion-reduce:animation-none transform-gpu transition-transform duration-300 hover:-translate-y-0.5";
+  "text-primary-foreground [background-size:260%_260%] bg-[linear-gradient(115deg,#3f3f3f_0%,#262626_50%,#0a0a0a_100%)] hover:bg-[linear-gradient(115deg,#0a0a0a_0%,#262626_50%,#3f3f3f_100%)] motion-safe:animation-[gradient-x_8s_linear_infinite] motion-reduce:animation-none transform-gpu transition-transform duration-300 hover:-translate-y-0.5";
 
 const buttonVariants = cva(
   "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
     variants: {
       variant: {
-        default: `${gradientInteractive} shadow-[0_18px_26px_-20px_rgba(15,23,42,0.68)] hover:shadow-[0_22px_34px_-22px_rgba(15,23,42,0.75)]`,
-        hero: `${gradientInteractive} shadow-[0_22px_34px_-18px_rgba(15,23,42,0.7)] hover:shadow-[0_26px_46px_-24px_rgba(15,23,42,0.78)]`,
+        default: `${gradientInteractive} shadow-[0_18px_26px_-20px_hsl(var(--brand-900)/0.6)] hover:shadow-[0_22px_34px_-22px_hsl(var(--brand-900)/0.68)]`,
+        hero: `${gradientInteractive} shadow-[0_22px_34px_-18px_hsl(var(--brand-900)/0.65)] hover:shadow-[0_26px_46px_-24px_hsl(var(--brand-900)/0.75)]`,
         destructive:
           "bg-destructive text-destructive-foreground hover:bg-destructive/90",
         outline:

--- a/client/components/ui/toast.tsx
+++ b/client/components/ui/toast.tsx
@@ -75,7 +75,7 @@ const ToastClose = React.forwardRef<
   <ToastPrimitives.Close
     ref={ref}
     className={cn(
-      "absolute right-2 top-2 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-2 group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600",
+      "absolute right-2 top-2 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-2 group-hover:opacity-100 group-[.destructive]:text-destructive group-[.destructive]:hover:text-destructive-foreground group-[.destructive]:focus:ring-destructive group-[.destructive]:focus:ring-offset-background",
       className,
     )}
     toast-close=""

--- a/client/global.css
+++ b/client/global.css
@@ -13,112 +13,105 @@
   */
   :root {
     --background: 0 0% 100%;
-    --foreground: 222.2 84% 4.9%;
+    --foreground: 0 0% 9%;
 
     --card: 0 0% 100%;
-    --card-foreground: 222.2 84% 4.9%;
+    --card-foreground: 0 0% 9%;
 
     --popover: 0 0% 100%;
-    --popover-foreground: 222.2 84% 4.9%;
+    --popover-foreground: 0 0% 9%;
 
-    --primary: 222.2 47.4% 11.2%;
-    --primary-foreground: 210 40% 98%;
+    --primary: 0 0% 9%;
+    --primary-foreground: 0 0% 98%;
 
-    --secondary: 210 40% 96.1%;
-    --secondary-foreground: 222.2 47.4% 11.2%;
+    --secondary: 0 0% 96%;
+    --secondary-foreground: 0 0% 9%;
 
-    --muted: 210 40% 96.1%;
-    --muted-foreground: 215.4 16.3% 46.9%;
+    --muted: 0 0% 90%;
+    --muted-foreground: 0 0% 25%;
 
-    --accent: 210 40% 96.1%;
-    --accent-foreground: 222.2 47.4% 11.2%;
+    --accent: 0 0% 83%;
+    --accent-foreground: 0 0% 9%;
 
-    --destructive: 0 84.2% 60.2%;
-    --destructive-foreground: 210 40% 98%;
+    --destructive: 0 0% 15%;
+    --destructive-foreground: 0 0% 96%;
 
-    --border: 214.3 31.8% 91.4%;
-    --input: 214.3 31.8% 91.4%;
-    --ring: 222.2 84% 4.9%;
+    --border: 0 0% 90%;
+    --input: 0 0% 90%;
+    --ring: 0 0% 9%;
 
     --radius: 0.5rem;
 
-    /* Brand scale (indigo/violet blend) */
-    --brand-50: 248 100% 97%;
-    --brand-100: 248 96% 93%;
-    --brand-200: 251 95% 85%;
-    --brand-300: 255 92% 76%;
-    --brand-400: 257 90% 68%;
-    --brand-500: 257 90% 61%;
-    --brand-600: 257 90% 54%;
-    --brand-700: 257 90% 47%;
-    --brand-800: 257 88% 40%;
-    --brand-900: 257 84% 34%;
+    /* Brand scale (grayscale) */
+    --brand-50: 0 0% 100%;
+    --brand-100: 0 0% 98%;
+    --brand-200: 0 0% 96%;
+    --brand-300: 0 0% 90%;
+    --brand-400: 0 0% 83%;
+    --brand-500: 0 0% 64%;
+    --brand-600: 0 0% 45%;
+    --brand-700: 0 0% 32%;
+    --brand-800: 0 0% 25%;
+    --brand-900: 0 0% 15%;
 
     --sidebar-background: 0 0% 98%;
-
-    --sidebar-foreground: 240 5.3% 26.1%;
-
-    --sidebar-primary: 240 5.9% 10%;
-
+    --sidebar-foreground: 0 0% 22%;
+    --sidebar-primary: 0 0% 9%;
     --sidebar-primary-foreground: 0 0% 98%;
-
-    --sidebar-accent: 240 4.8% 95.9%;
-
-    --sidebar-accent-foreground: 240 5.9% 10%;
-
-    --sidebar-border: 220 13% 91%;
-
-    --sidebar-ring: 217.2 91.2% 59.8%;
+    --sidebar-accent: 0 0% 90%;
+    --sidebar-accent-foreground: 0 0% 9%;
+    --sidebar-border: 0 0% 90%;
+    --sidebar-ring: 0 0% 15%;
   }
 
   .dark {
-    --background: 222.2 84% 4.9%;
-    --foreground: 210 40% 98%;
+    --background: 0 0% 0%;
+    --foreground: 0 0% 96%;
 
-    --card: 222.2 84% 4.9%;
-    --card-foreground: 210 40% 98%;
+    --card: 0 0% 3%;
+    --card-foreground: 0 0% 96%;
 
-    --popover: 222.2 84% 4.9%;
-    --popover-foreground: 210 40% 98%;
+    --popover: 0 0% 3%;
+    --popover-foreground: 0 0% 96%;
 
-    --primary: 210 40% 98%;
-    --primary-foreground: 222.2 47.4% 11.2%;
+    --primary: 0 0% 98%;
+    --primary-foreground: 0 0% 0%;
 
-    --secondary: 217.2 32.6% 17.5%;
-    --secondary-foreground: 210 40% 98%;
+    --secondary: 0 0% 15%;
+    --secondary-foreground: 0 0% 96%;
 
-    --muted: 217.2 32.6% 17.5%;
-    --muted-foreground: 215 20.2% 65.1%;
+    --muted: 0 0% 15%;
+    --muted-foreground: 0 0% 64%;
 
-    --accent: 217.2 32.6% 17.5%;
-    --accent-foreground: 210 40% 98%;
+    --accent: 0 0% 22%;
+    --accent-foreground: 0 0% 96%;
 
-    --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 210 40% 98%;
+    --destructive: 0 0% 32%;
+    --destructive-foreground: 0 0% 96%;
 
-    --border: 217.2 32.6% 17.5%;
-    --input: 217.2 32.6% 17.5%;
-    --ring: 212.7 26.8% 83.9%;
+    --border: 0 0% 15%;
+    --input: 0 0% 15%;
+    --ring: 0 0% 64%;
 
-    --brand-50: 247 53% 10%;
-    --brand-100: 249 55% 14%;
-    --brand-200: 251 58% 20%;
-    --brand-300: 253 61% 28%;
-    --brand-400: 255 64% 36%;
-    --brand-500: 257 67% 44%;
-    --brand-600: 257 70% 52%;
-    --brand-700: 257 74% 58%;
-    --brand-800: 257 78% 64%;
-    --brand-900: 257 82% 72%;
+    --brand-50: 0 0% 0%;
+    --brand-100: 0 0% 3%;
+    --brand-200: 0 0% 9%;
+    --brand-300: 0 0% 15%;
+    --brand-400: 0 0% 22%;
+    --brand-500: 0 0% 32%;
+    --brand-600: 0 0% 54%;
+    --brand-700: 0 0% 64%;
+    --brand-800: 0 0% 83%;
+    --brand-900: 0 0% 96%;
 
-    --sidebar-background: 240 5.9% 10%;
-    --sidebar-foreground: 240 4.8% 95.9%;
-    --sidebar-primary: 224.3 76.3% 48%;
-    --sidebar-primary-foreground: 0 0% 100%;
-    --sidebar-accent: 240 3.7% 15.9%;
-    --sidebar-accent-foreground: 240 4.8% 95.9%;
-    --sidebar-border: 240 3.7% 15.9%;
-    --sidebar-ring: 217.2 91.2% 59.8%;
+    --sidebar-background: 0 0% 3%;
+    --sidebar-foreground: 0 0% 83%;
+    --sidebar-primary: 0 0% 98%;
+    --sidebar-primary-foreground: 0 0% 0%;
+    --sidebar-accent: 0 0% 15%;
+    --sidebar-accent-foreground: 0 0% 90%;
+    --sidebar-border: 0 0% 15%;
+    --sidebar-ring: 0 0% 64%;
   }
 }
 
@@ -132,7 +125,7 @@
     background-image:
       radial-gradient(
         1000px 600px at 50% -200px,
-        hsl(var(--brand-600) / 0.18),
+        hsl(var(--brand-500) / 0.16),
         transparent 60%
       ),
       radial-gradient(
@@ -142,10 +135,10 @@
       ),
       radial-gradient(
         700px 420px at 90% 30%,
-        hsl(var(--brand-700) / 0.12),
+        hsl(var(--brand-600) / 0.12),
         transparent 60%
       ),
-      linear-gradient(to bottom, hsl(222.2 84% 4.9%), hsl(222.2 84% 4.9%));
+      linear-gradient(to bottom, hsl(var(--background)), hsl(var(--background)));
     background-attachment: fixed;
     background-repeat: no-repeat;
     background-size: cover;

--- a/client/pages/About.tsx
+++ b/client/pages/About.tsx
@@ -45,7 +45,7 @@ export default function About() {
           {features.map((f) => (
             <div
               key={f.title}
-              className="relative overflow-hidden rounded-2xl border border-white/12 bg-white/10 p-6 shadow-[0_18px_36px_-24px_rgba(15,23,42,0.6)] backdrop-blur-2xl before:pointer-events-none before:absolute before:inset-0 before:rounded-2xl before:bg-gradient-to-br before:from-white/30 before:via-white/10 before:to-transparent before:opacity-70 dark:border-white/10 dark:bg-white/5 dark:before:from-white/15 dark:shadow-[0_20px_40px_-28px_rgba(0,0,0,0.8)]"
+              className="relative overflow-hidden rounded-2xl border border-border/70 bg-card/80 p-6 shadow-[0_18px_36px_-24px_rgba(0,0,0,0.4)] backdrop-blur-2xl before:pointer-events-none before:absolute before:inset-0 before:rounded-2xl before:bg-gradient-to-br before:from-foreground/10 before:via-foreground/5 before:to-transparent before:opacity-70 dark:border-border/60 dark:bg-card/60 dark:before:from-foreground/15 dark:shadow-[0_20px_40px_-28px_rgba(0,0,0,0.7)]"
             >
               <h2 className="text-xl font-semibold">{f.title}</h2>
               <p className="mt-2 text-foreground/80">{f.desc}</p>

--- a/client/pages/Auth.tsx
+++ b/client/pages/Auth.tsx
@@ -50,7 +50,7 @@ export default function AuthPage() {
               <div className="grid gap-3">
                 <Button
                   variant="secondary"
-                  className="w-full bg-white text-black hover:opacity-90 border border-border dark:bg-white dark:text-black flex items-center justify-center gap-2 h-11 rounded-xl"
+                  className="flex h-11 w-full items-center justify-center gap-2 rounded-xl border border-border bg-background text-foreground hover:bg-background/80 dark:bg-card dark:text-foreground"
                   onClick={handleGoogle}
                   disabled={loading}
                 >

--- a/client/pages/Auth.tsx
+++ b/client/pages/Auth.tsx
@@ -45,7 +45,9 @@ export default function AuthPage() {
             </div>
 
             <div className="rounded-2xl border border-border bg-card/80 shadow-lg shadow-brand-500/10 ring-1 ring-brand-500/10 backdrop-blur p-6">
-              {error && <p className="mb-4 text-sm text-destructive">{error}</p>}
+              {error && (
+                <p className="mb-4 text-sm text-destructive">{error}</p>
+              )}
 
               <div className="grid gap-3">
                 <Button

--- a/client/pages/Auth.tsx
+++ b/client/pages/Auth.tsx
@@ -45,7 +45,7 @@ export default function AuthPage() {
             </div>
 
             <div className="rounded-2xl border border-border bg-card/80 shadow-lg shadow-brand-500/10 ring-1 ring-brand-500/10 backdrop-blur p-6">
-              {error && <p className="mb-4 text-sm text-red-500">{error}</p>}
+              {error && <p className="mb-4 text-sm text-destructive">{error}</p>}
 
               <div className="grid gap-3">
                 <Button

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -38,18 +38,18 @@ export default function Index() {
   return (
     <Layout>
       <section className="relative flex items-center justify-center overflow-hidden py-24 md:py-36">
-        <div className="absolute inset-0 -z-20 bg-[radial-gradient(ellipse_at_top,theme(colors.brand.500/12),transparent_55%)]" />
+        <div className="absolute inset-0 -z-20 bg-[radial-gradient(ellipse_at_top,theme(colors.brand.500/14),transparent_55%)]" />
         <div className="pointer-events-none absolute -top-24 left-1/2 -z-10 h-72 w-72 -translate-x-1/2 rounded-full bg-brand-500/25 blur-3xl" />
-        <div className="pointer-events-none absolute bottom-8 right-10 -z-10 h-64 w-64 rounded-full bg-fuchsia-500/20 blur-[120px]" />
-        <div className="pointer-events-none absolute top-16 left-10 -z-10 hidden h-56 w-56 rounded-full bg-cyan-400/20 blur-3xl sm:block" />
+        <div className="pointer-events-none absolute bottom-8 right-10 -z-10 h-64 w-64 rounded-full bg-brand-700/20 blur-[120px]" />
+        <div className="pointer-events-none absolute top-16 left-10 -z-10 hidden h-56 w-56 rounded-full bg-brand-300/25 blur-3xl sm:block" />
         <div className="absolute inset-0 -z-10 bg-gradient-to-b from-brand-600/20 via-background/0 to-background/30" />
         <div className="container mx-auto">
           <div className="mx-auto max-w-3xl text-center">
             <h1>
               <AnimatedGradientText
                 speed={2}
-                colorFrom="#4ade80"
-                colorTo="#06b6d4"
+                colorFrom="#a3a3a3"
+                colorTo="#0a0a0a"
                 className="text-4xl font-black tracking-tight md:text-6xl"
               >
                 Check if your data has been leaked
@@ -64,8 +64,8 @@ export default function Index() {
               usernames, IPs, or domains.
             </p>
             <div className="mt-10 grid gap-4">
-              <div className="group relative overflow-hidden rounded-3xl border border-white/20 bg-white/10 p-2 shadow-2xl shadow-cyan-500/20 ring-1 ring-cyan-500/25 backdrop-blur-2xl transition dark:border-white/10 dark:bg-white/5">
-                <div className="pointer-events-none absolute inset-0 -z-10 hidden md:block bg-[radial-gradient(1200px_600px_at_50%_-200px,theme(colors.emerald.400/0.12),transparent_60%)]" />
+              <div className="group relative overflow-hidden rounded-3xl border border-border/80 bg-card/90 p-2 shadow-[0_24px_48px_-28px_rgba(0,0,0,0.5)] ring-1 ring-brand-800/25 backdrop-blur-2xl transition dark:border-border/60 dark:bg-card/70">
+                <div className="pointer-events-none absolute inset-0 -z-10 hidden md:block bg-[radial-gradient(1200px_600px_at_50%_-200px,theme(colors.brand.500/0.16),transparent_60%)]" />
                 <input
                   value={query}
                   onChange={(e) =>

--- a/client/pages/OsintInfoResults.tsx
+++ b/client/pages/OsintInfoResults.tsx
@@ -297,7 +297,7 @@ export default function OsintInfoResults() {
                 </div>
               </div>
             ) : profile && computeRemaining(profile) <= 0 ? (
-              <div className="mx-auto max-w-md rounded-2xl border border-dashed border-amber-400/40 bg-amber-500/10 p-8 text-center">
+              <div className="mx-auto max-w-md rounded-2xl border border-dashed border-brand-700/40 bg-brand-900/10 p-8 text-center">
                 <p className="text-base font-semibold text-foreground">
                   No searches remaining.
                 </p>

--- a/client/pages/Shop.tsx
+++ b/client/pages/Shop.tsx
@@ -95,13 +95,13 @@ function PlanCard({ plan, onEmail }: PlanCardProps) {
             "perspective(1100px) rotateX(var(--rx, 0deg)) rotateY(var(--ry, 0deg)) translateZ(var(--tz, 0px))",
         }}
       >
-        <div className="pointer-events-none absolute inset-x-6 -bottom-4 h-12 translate-y-3 rounded-full bg-slate-900/25 blur-lg transition-all duration-200 group-hover:translate-y-0.5 dark:bg-black/40" />
-        <Card className="relative h-full overflow-hidden rounded-2xl border border-white/12 bg-white/10 px-2 pb-6 pt-4 shadow-[0_18px_36px_-24px_rgba(15,23,42,0.6)] backdrop-blur-2xl transition-[box-shadow,transform] duration-150 group-hover:-translate-y-0.5 hover:shadow-[0_22px_48px_-28px_rgba(15,23,42,0.72)] dark:border-white/10 dark:bg-white/5 dark:shadow-[0_20px_40px_-28px_rgba(0,0,0,0.82)] dark:hover:shadow-[0_24px_50px_-32px_rgba(0,0,0,0.88)]">
+        <div className="pointer-events-none absolute inset-x-6 -bottom-4 h-12 translate-y-3 rounded-full bg-brand-900/25 blur-lg transition-all duration-200 group-hover:translate-y-0.5 dark:bg-brand-300/30" />
+        <Card className="relative h-full overflow-hidden rounded-2xl border border-border/70 bg-card/85 px-2 pb-6 pt-4 shadow-[0_18px_36px_-24px_rgba(0,0,0,0.45)] backdrop-blur-2xl transition-[box-shadow,transform] duration-150 group-hover:-translate-y-0.5 hover:shadow-[0_22px_48px_-28px_rgba(0,0,0,0.62)] dark:border-border/60 dark:bg-card/65 dark:shadow-[0_20px_40px_-28px_rgba(0,0,0,0.7)] dark:hover:shadow-[0_24px_50px_-32px_rgba(0,0,0,0.8)]">
           <div
             className="pointer-events-none absolute inset-0 rounded-2xl opacity-0 transition-opacity duration-150 group-hover:opacity-100"
             style={{
               background:
-                "radial-gradient(100px 70px at var(--px, -100px) var(--py, -100px), rgba(6, 182, 212, 0.18), rgba(6, 182, 212, 0) 60%)",
+                "radial-gradient(100px 70px at var(--px, -100px) var(--py, -100px), rgba(64,64,64,0.22), rgba(64,64,64,0) 60%)",
               mixBlendMode: "screen",
             }}
           />
@@ -110,7 +110,7 @@ function PlanCard({ plan, onEmail }: PlanCardProps) {
               <span className="text-4xl font-extrabold text-foreground">
                 {plan.searches}
               </span>{" "}
-              <span className="align-super text-xs font-semibold uppercase tracking-[0.5em] text-amber-400">
+              <span className="align-super text-xs font-semibold uppercase tracking-[0.5em] text-brand-600">
                 searches
               </span>
             </CardTitle>


### PR DESCRIPTION
## Changes Made

This pull request updates the color scheme across multiple components from brand-specific colors to a more neutral theme.

### Component Updates

**MaskedInfoTicker.tsx**
- Changed text shadow from purple brand color `rgba(79,70,229,0.25)` to neutral black `rgba(0,0,0,0.25)`

**FeatureGrid.tsx**
- Updated card styling from hardcoded white/transparent colors to CSS custom properties (`border-border`, `bg-card`)
- Changed shadow colors from slate-specific values to neutral black with adjusted opacity
- Updated gradient overlays from white-based to foreground-based custom properties

**Header.tsx**
- Changed navigation underline from amber (`bg-amber-400/70`) to foreground-based (`bg-foreground/40`)
- Updated search balance button from amber theme to brand theme with custom properties
- Modified button styling to use `text-primary-foreground` and brand color variables

**ResultsList.tsx**
- Updated card shadows from slate-specific colors to neutral black
- Changed link colors from amber (`text-amber-300`) to brand colors (`text-brand-800`)
- Updated shadow values throughout result cards

**Button Component**
- Modified gradient interactive styling from green/cyan gradient to neutral gray gradient
- Updated text color to use `text-primary-foreground`

**Global Styles**
- Updated sidebar color variables to use neutral grays
- Modified background gradient from brand-specific colors to use CSS custom properties
- Changed radial gradient colors to use brand variables instead of hardcoded values

**Page Components (About.tsx, Auth.tsx, Index.tsx, OsintInfoResults.tsx, Shop.tsx)**
- Replaced hardcoded color values with CSS custom properties
- Updated card styling to use `border-border` and `bg-card` variables
- Changed gradient colors from specific brand colors to neutral/brand variables
- Modified shadow colors from slate/specific colors to neutral black values

### Impact

This change creates a more consistent and maintainable color system by replacing hardcoded color values with CSS custom properties and moving from brand-specific colors to a neutral theme.

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/ef238acda29d4536bbb2370e3a8130dd/nova-verse)

👀 [Preview Link](https://ef238acda29d4536bbb2370e3a8130dd-nova-verse.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ef238acda29d4536bbb2370e3a8130dd</projectId>-->
<!--<branchName>nova-verse</branchName>-->